### PR TITLE
Set up aws lambda contact and email template

### DIFF
--- a/aws/email/email-service-aws-lambda.js
+++ b/aws/email/email-service-aws-lambda.js
@@ -1,0 +1,24 @@
+/* eslint-env node */
+
+// Load the AWS SDK for Node.js
+const AWS = require('aws-sdk');
+// Set the region
+AWS.config.update({region: 'us-east-1'});
+
+exports.handler = (event, _, callback) => {
+  const params = {
+    Destination: {
+      ToAddresses: [process.env.EMAIL_ADDRESS_TO]
+    },
+    Source: process.env.EMAIL_ADDRESS_FROM,
+    Template: process.env.TEMPLATE_NAME /* required */,
+    TemplateData: `{ "email":"${event.email}", "link":"${event.link}", "message":"${event.message}", "name":"${
+      event.name
+    }" }`,
+    ReplyToAddresses: [process.env.EMAIL_ADDRESS_FROM]
+  };
+
+  const sendPromise = new AWS.SES().sendTemplatedEmail(params).promise();
+
+  sendPromise.then(data => callback(null, data)).catch(err => callback(err, err.stack));
+};

--- a/aws/email/email-template.json
+++ b/aws/email/email-template.json
@@ -1,0 +1,9 @@
+{
+  "Template": {
+    "TemplateName": "RDC-Etudes-Contact-Form",
+    "SubjectPart": "Nouveau message RDC-Etudes de {{name}}!",
+    "HtmlPart":
+      "<dl><dt>Lien:</dt><dd>{{link}}</dd><dt>Nom:</dt><dd>{{name}}</dd><dt>Email:</dt><dd>{{email}}</dd><dt>Message:</dt><dd>{{message}}</dd></dl>",
+    "TextPart": "Lien: {{link}},\r\nNom: {{name}},\r\nEmail: {{email}},\r\nMessage: {{message}}."
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "lint": "./node_modules/.bin/stylelint './src/**/*.scss' && ./node_modules/.bin/eslint './src/**/*.js'",
     "precommit": "lint-staged",
     "prettier": "prettier --write 'src/**/*.{js,json,scss,md}'",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "update-contact-email-template":
+      "aws ses update-template --cli-input-json file://aws/email/email-template.json --region=us-east-1"
   },
   "lint-staged": {
     "*.{js,json,scss,md}": ["prettier --write", "git add"]


### PR DESCRIPTION
Set up an aws lambda function to handle contact form emails and add an email template for the email to be send to the admin when a new contact request is in.