### PR TITLE
Add react next plugin to use React v16

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -5,6 +5,7 @@ module.exports = {
     'gatsby-plugin-react-helmet',
     'gatsby-transformer-sharp',
     'gatsby-plugin-sharp',
+    'gatsby-plugin-react-next',
     {
       resolve: 'gatsby-source-filesystem',
       options: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8037,6 +8037,43 @@
         "babel-runtime": "6.26.0"
       }
     },
+    "gatsby-plugin-react-next": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-react-next/-/gatsby-plugin-react-next-1.0.11.tgz",
+      "integrity": "sha1-cVyrXqhvZGZPlq8+fzZA7s2d5eM=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.3",
+        "react": "16.3.1",
+        "react-dom": "16.3.1"
+      },
+      "dependencies": {
+        "react": {
+          "version": "16.3.1",
+          "resolved": "https://registry.npmjs.org/react/-/react-16.3.1.tgz",
+          "integrity":
+            "sha512-NbkxN9jsZ6+G+ICsLdC7/wUD26uNbvKU/RAxEWgc9kcdKvROt+5d5j2cNQm5PSFTQ4WNGsR3pa4qL2Q0/WSy1w==",
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.0"
+          }
+        },
+        "react-dom": {
+          "version": "16.3.1",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.3.1.tgz",
+          "integrity":
+            "sha512-2Infg89vzahq8nfVi1GkjPqq0vrBvf0f3T0+dTtyjq4f6HKOqKixAK25Vr593O3QTx4kw/vmUtAJwerlevNWOA==",
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.0"
+          }
+        }
+      }
+    },
     "gatsby-plugin-sharp": {
       "version": "1.6.41",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-sharp/-/gatsby-plugin-sharp-1.6.41.tgz",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "gatsby-image": "^1.0.42",
     "gatsby-link": "^1.6.39",
     "gatsby-plugin-react-helmet": "^2.0.8",
+    "gatsby-plugin-react-next": "^1.0.11",
     "gatsby-plugin-sharp": "^1.6.41",
     "gatsby-remark-copy-linked-files": "^1.5.30",
     "gatsby-remark-images": "^1.5.60",


### PR DESCRIPTION
Dans le but d'utiliser la dernière version de React, on ajoute `gatsby-react-next-plugin`.

This resolves #31 